### PR TITLE
feat: support API v0.0.3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export class APIClient {
 
 	public async createEvent(data: EventCreationData): Promise<ProcessedAPIEvent> {
 		if (data.startTime instanceof Date) data.startTime = data.startTime.toISOString();
-		if (data.endTime instanceof Date) data.startTime = data.endTime.toISOString();
+		if (data.endTime instanceof Date) data.endTime = data.endTime.toISOString();
 		const formData = new FormData();
 
 		for (const [key, value] of Object.entries(data)) {
@@ -115,7 +115,7 @@ export class APIClient {
 		*/
 		const contentTypeExtra = (formData.getBoundary as any) ? ` boundary=${formData.getBoundary()}` : '';
 
-		const response: AxiosResponse<{ event: APIEvent }> = await axios.put(`${this.apiBase}/events`, formData, {
+		const response: AxiosResponse<{ event: APIEvent }> = await axios.post(`${this.apiBase}/events`, formData, {
 			...this.baseConfig,
 			headers: {
 				...this.baseConfig.headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,24 @@ export class APIClient {
 	public async createEvent(data: EventCreationData): Promise<ProcessedAPIEvent> {
 		if (data.startTime instanceof Date) data.startTime = data.startTime.toISOString();
 		if (data.endTime instanceof Date) data.startTime = data.endTime.toISOString();
+		const formData = new FormData();
 
-		const response: AxiosResponse<{ event: APIEvent }> = await axios.post(`${this.apiBase}/events`, data, this.baseConfig);
+		for (const [key, value] of Object.entries(data)) {
+			formData.append(key, (key === 'image' && typeof value === 'boolean') ? String(value) : value);
+		}
+
+		/*
+			In Node-land, formData.getBoundary is a defined function, and in browser this is undefined and not really required.
+		*/
+		const contentTypeExtra = (formData.getBoundary as any) ? ` boundary=${formData.getBoundary()}` : '';
+
+		const response: AxiosResponse<{ event: APIEvent }> = await axios.put(`${this.apiBase}/events`, formData, {
+			...this.baseConfig,
+			headers: {
+				...this.baseConfig.headers,
+				'Content-Type': `multipart/form-data;${contentTypeExtra}`
+			}
+		});
 		return {
 			...response.data.event,
 			startTime: new Date(response.data.event.startTime),
@@ -116,8 +132,24 @@ export class APIClient {
 	public async editEvent(data: EventEditData): Promise<ProcessedAPIEvent> {
 		if (data.startTime instanceof Date) data.startTime = data.startTime.toISOString();
 		if (data.endTime instanceof Date) data.startTime = data.endTime.toISOString();
+		const formData = new FormData();
 
-		const response: AxiosResponse<{ event: APIEvent }> = await axios.patch(`${this.apiBase}/events/${data.id}`, data, this.baseConfig);
+		for (const [key, value] of Object.entries(data)) {
+			formData.append(key, (key === 'image' && typeof value === 'boolean') ? String(value) : value);
+		}
+
+		/*
+			In Node-land, formData.getBoundary is a defined function, and in browser this is undefined and not really required.
+		*/
+		const contentTypeExtra = (formData.getBoundary as any) ? ` boundary=${formData.getBoundary()}` : '';
+
+		const response: AxiosResponse<{ event: APIEvent }> = await axios.patch(`${this.apiBase}/events/${data.id}`, formData, {
+			...this.baseConfig,
+			headers: {
+				...this.baseConfig.headers,
+				'Content-Type': `multipart/form-data;${contentTypeExtra}`
+			}
+		});
 		return {
 			...response.data.event,
 			startTime: new Date(response.data.event.startTime),

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -45,6 +45,7 @@ export interface EventCreationData {
 	endTime: string | Date;
 	description: string;
 	external: string;
+	image?: File|boolean;
 }
 
 export type EventEditData = { id: string } & Partial<EventCreationData>;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -75,6 +75,7 @@ export interface APIEvent {
 	endTime: string;
 	description: string;
 	external: string;
+	image: boolean;
 	channelID: string;
 }
 

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -5,6 +5,8 @@ export enum GatewayPacketType {
 	Hello = 'HELLO',
 	MessageCreate = 'MESSAGE_CREATE',
 	MessageDelete = 'MESSAGE_DELETE',
+	Ping = 'PING',
+	Pong = 'PONG',
 	// Sent by the client to join a Discovery queue
 	JoinDiscoveryQueue = 'JOIN_DISCOVERY_QUEUE',
 	// Sent by the client to leave a Discovery queue
@@ -31,6 +33,20 @@ export interface IdentifyGatewayPacket extends GatewayPacket {
 
 export interface HelloGatewayPacket extends GatewayPacket {
 	type: GatewayPacketType.Hello;
+}
+
+export interface PingGatewayPacket {
+	type: GatewayPacketType.Ping;
+	data: {
+		timestamp: number;
+	};
+}
+
+export interface PongGatewayPacket {
+	type: GatewayPacketType.Pong;
+	data: {
+		timestamp: number;
+	};
 }
 
 export interface MessageCreateGatewayPacket extends GatewayPacket {


### PR DESCRIPTION
- Supports uploading and editing event images. and the `image` property on APIEvent
- Fixes support for gateway
  - Uses correct WebSocket in browser
  - Now supports one-sided heartbeating (the client will have to add support for discovering it has not received a heartbeat from the gateway in a future release) to keep the connection alive