### PR TITLE
feat: add Client#destroy method

### DIFF
--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -36,8 +36,8 @@ export class GatewayClient extends EventEmitter {
 	}
 
 	public destroy() {
-		this.ws.close();
 		this.lifetimeState = State.Destroyed;
+		this.ws.close();
 	}
 
 	public get status() {

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -107,8 +107,17 @@ export class GatewayClient extends EventEmitter {
 
 	private onClose(event: NodeWebSocket.CloseEvent) {
 		if (this.lifetimeState === State.Destroyed) {
-			this.emit('disconnected');
+			/**
+			 * Emitted when the client has disconnected and will not attempt to reconnect as the gateway has been marked
+			 * as being destroyed. This only occurs when APIClient#destroy() is called.
+			 * @event GatewayClient#destroyed
+			 */
+			this.emit('destroyed');
 		} else {
+			/**
+			 * Emitted when the client will try to reconnect to the gateway (with a 3 second backoff)
+			 * @event GatewayClient#reconnecting
+			 */
 			this.emit('reconnecting', event);
 			setTimeout(() => this.connect(), 3e3);
 		}

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -16,6 +16,7 @@ export class GatewayClient extends EventEmitter {
 	private readonly useWss: boolean;
 	private _inDiscoveryQueue: boolean;
 	private lifetimeState: State;
+	private connectTimeout?: NodeJS.Timeout;
 
 	public constructor(apiClient: APIClient, useWss = false) {
 		super();
@@ -37,6 +38,7 @@ export class GatewayClient extends EventEmitter {
 
 	public destroy() {
 		this.lifetimeState = State.Destroyed;
+		if (this.connectTimeout) clearTimeout(this.connectTimeout);
 		this.ws.close();
 	}
 
@@ -119,7 +121,7 @@ export class GatewayClient extends EventEmitter {
 			 * @event GatewayClient#reconnecting
 			 */
 			this.emit('reconnecting', event);
-			setTimeout(() => this.connect(), 3e3);
+			this.connectTimeout = setTimeout(() => this.connect(), 3e3);
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,14 @@ export class APIClient {
 		this.useWss = data.useWss ?? false;
 	}
 
+	public destroy() {
+		this.token = undefined;
+		if (this.gateway) {
+			this.gateway.destroy();
+			this.gateway = undefined;
+		}
+	}
+
 	public get isAuthorized() {
 		return Boolean(this.token);
 	}


### PR DESCRIPTION
## About

Allows for destroying any session-specific data attached to an APIClient, and destroying its gateway connection (if it has one!) This technically allows the client to be reused, by setting its token again and calling it `initGateway()` again.

This also adds a fixed 3 second wait time to the Gateway before it tries to reconnect if the connection unexpectedly drops.