### PR TITLE
feat!: add pagination support to getMessages

### DIFF
--- a/src/__tests__/getMessages.test.ts
+++ b/src/__tests__/getMessages.test.ts
@@ -15,7 +15,7 @@ test('getMessage(): 0 messages gives empty list', async () => {
 	mock.onGet('unics-social/channels/3/messages').reply(200, {
 		messages: []
 	});
-	const messages = await apiClientInit.getMessages('3');
+	const messages = await apiClientInit.getMessages({ channelID: '3' });
 	expect(messages.length).toEqual(0);
 });
 
@@ -24,7 +24,7 @@ test('getMessages(): 1 message', async () => {
 	mock.onGet('unics-social/channels/2/messages').reply(200, {
 		messages: [validMessages[3]]
 	});
-	const messages = await apiClientInit.getMessages('2');
+	const messages = await apiClientInit.getMessages({ channelID: '2' });
 	expect(messages).toEqual([validMessages[3]]);
 });
 
@@ -32,7 +32,7 @@ test('getMessages(): more than 1 message fetched correctly', async () => {
 	mock.onGet('unics-social/channels/1/messages').reply(200, {
 		messages: validMessages.slice(0, 3)
 	});
-	const messages = await apiClientInit.getMessages('1');
+	const messages = await apiClientInit.getMessages({ channelID: '1' });
 	expect(messages).toEqual(validMessages.slice(0, 3));
 });
 
@@ -40,5 +40,5 @@ test('getMessages(): throws when API response has error code', async () => {
 	mock.onGet('unics-social/channels/4/messages').reply(404, {
 		error: 'Message not found'
 	});
-	await expect(apiClientInit.getMessages('4')).rejects.toThrow();
+	await expect(apiClientInit.getMessages({ channelID: '4' })).rejects.toThrow();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,8 +178,8 @@ export class APIClient {
 		return response.data.message;
 	}
 
-	public async getMessages(channelID: string): Promise<APIMessage[]> {
-		const response: AxiosResponse<{ messages: APIMessage[] }> = await axios.get(`${this.apiBase}/channels/${channelID}/messages`, this.baseConfig);
+	public async getMessages({ channelID, before }: { channelID: string; before?: Date }): Promise<APIMessage[]> {
+		const response: AxiosResponse<{ messages: APIMessage[] }> = await axios.get(`${this.apiBase}/channels/${channelID}/messages?before=${before?.toISOString() ?? ''}`, this.baseConfig);
 		return response.data.messages;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,8 @@ export class APIClient {
 	}
 
 	public async getMessages({ channelID, before }: { channelID: string; before?: Date }): Promise<APIMessage[]> {
-		const response: AxiosResponse<{ messages: APIMessage[] }> = await axios.get(`${this.apiBase}/channels/${channelID}/messages?before=${before?.toISOString() ?? ''}`, this.baseConfig);
+		const extra = before ? `?before=${before.toISOString()}` : '';
+		const response: AxiosResponse<{ messages: APIMessage[] }> = await axios.get(`${this.apiBase}/channels/${channelID}/messages${extra}`, this.baseConfig);
 		return response.data.messages;
 	}
 


### PR DESCRIPTION
Adds time-based pagination﻿ support to getMessages. Breaking change as getMessages now takes an object containing a channelID, as opposed to a single parameter that's the channel ID.
